### PR TITLE
feat: Add Dockerfile and nginx-conf configmap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:14.18.0 as builder
+
+ARG YARN_VERSION=1.22.4
+
+WORKDIR /openelb
+
+ADD . /openelb/
+
+RUN npm install yarn@${YARN_VERSION}
+
+RUN yarn && yarn build
+
+FROM nginx
+
+COPY --from=builder /openelb/build /openelb
+

--- a/nginx-configmap.yaml
+++ b/nginx-configmap.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openelb-nginx-conf
+data:
+  default.conf: | -
+    server {
+      listen       8088;
+      listen  [::]:8088;
+      server_name  localhost;
+  
+      add_header Access-Control-Allow-Origin *;
+      add_header Access-Control-Allow-Methods 'GET, POST, OPTIONS';
+      add_header Access-Control-Allow-Headers 'DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization';
+  
+      if ($request_method = 'OPTIONS') {
+          return 204;
+      }
+  
+      root /openelb;
+  
+      location /apis {
+          proxy_pass http://server.domain:port;
+          proxy_connect_timeout 600;
+          proxy_read_timeout 600;
+      }
+  
+      location / {
+          try_files $uri $uri/ @router;
+          index  index.html index.htm;
+      }
+  
+      location @router {
+          rewrite ^.*$ /index.html last;
+      }
+    }


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

If we want to deploy it in k8s, we should create a configmap for it,
and mount that into container's `/etc/nginx/conf.d/default.conf`.