### PR TITLE
use trigger to perform actions in eip-details page

### DIFF
--- a/src/actions/BGP.js
+++ b/src/actions/BGP.js
@@ -1,5 +1,6 @@
 import Modal from "../components/Base/Modal"
 import createModal from "../components/Modal/Create"
+import createBgpConfModel from "../components/Modal/BgpConfCreate"
 import CommonAction from "./base"
 import steps from "../steps/bgppeer"
 import FORM_TEMPLATES from "../utils/form.templates"
@@ -27,7 +28,23 @@ const Actions = {
     on() {
       console.log('bgp editInfo')
     }
-  }
+  },
+  "bgpconf.create": {
+    on({ store }) {
+      const formTemplate = FORM_TEMPLATES['bgpconf']()
+      const modal = Modal.open({
+        onOk: (formData) => {
+          // TODO
+          // need to implement the create action in eip Store
+        },
+        modal: createBgpConfModel,
+        name: 'BgpConf',
+        formTemplate,
+        store,
+        okBtnText: 'create',
+      })
+    }
+  },
 }
 
 export default Actions

--- a/src/actions/BGP.js
+++ b/src/actions/BGP.js
@@ -1,50 +1,121 @@
+import { Notify } from '@kube-design/components'
 import Modal from "../components/Base/Modal"
-import createModal from "../components/Modal/Create"
-import createBgpConfModel from "../components/Modal/BgpConfCreate"
+import CreateModal from "../components/Modal/Create"
+import EditSettingsModal from "../components/Modal/EditSettings"
+import CreateBgpConfModel from "../components/Modal/BgpConfCreate"
+import formBgpConfModel from "../components/Forms/BGPConf"
 import CommonAction from "./base"
 import steps from "../steps/bgppeer"
 import FORM_TEMPLATES from "../utils/form.templates"
+import EditYAMLModal from "../components/Modal/EditYAML.jsx"
+import { isUndefined } from "lodash"
 
 const Actions = {
   ...CommonAction,
   "bgp.create": {
-    on({ store }) {
+    on({ store, success, ...props }) {
       const formTemplate = FORM_TEMPLATES['bgp']()
       const modal = Modal.open({
         onOk: (formData) => {
-          // TODO
-          // need to implement the create action in eip Store
+          if (!isUndefined(formData.spec.nodeSelector) &&
+            !formData.spec.nodeSelector.matchLabels["openelb.kubesphere.io/rack"]) {
+            delete formData.spec.nodeSelector.matchLabels
+          }
+          store.create(formData).then(() => {
+            Modal.close(modal)
+            Notify.success({ content: "Created Successfully." })
+            success && success()
+          })
         },
-        modal: createModal,
+        modal: CreateModal,
         steps,
         name: 'BgpPeer',
         formTemplate,
         store,
-        okBtnText: 'create',
+        okBtnText: 'Create',
+        ...props,
       })
     }
   },
-  "bgp.editInfo": {
-    on() {
-      console.log('bgp editInfo')
-    }
+  "bgp.settings.edit": {
+    on({ store, detail, success, ...props }) {
+      const modal = Modal.open({
+        onOk: data => {
+          store.patch(detail, data).then(() => {
+            Modal.close(modal)
+            Notify.success({ content: "Updated successfully." })
+            success && success()
+          })
+        },
+        detail,
+        modal: EditSettingsModal,
+        title: 'Edit BgpPeer',
+        store,
+        ...props,
+      })
+    },
+  },
+  "bgp.yaml.edit": {
+    on({ store, detail, success, ...props }) {
+      const modal = Modal.open({
+        onOk: data => {
+          delete data.status
+          store.patch(detail, data).then(() => {
+            Modal.close(modal)
+            Notify.success({ content: "Updated successfully." })
+            success && success()
+          })
+        },
+        detail,
+        modal: EditYAMLModal,
+        store,
+        ...props,
+      })
+    },
   },
   "bgpconf.create": {
-    on({ store }) {
+    on({ store, success, ...props }) {
       const formTemplate = FORM_TEMPLATES['bgpconf']()
       const modal = Modal.open({
         onOk: (formData) => {
-          // TODO
-          // need to implement the create action in eip Store
+          store.createConf(formData).then(() => {
+            Modal.close(modal)
+            Notify.success({ content: "Created successfully." })
+            success && success()
+          })
         },
-        modal: createBgpConfModel,
+        modal: CreateBgpConfModel,
+        formModal: formBgpConfModel,
+        create: true,
         name: 'BgpConf',
         formTemplate,
         store,
-        okBtnText: 'create',
+        okBtnText: 'Create',
+        ...props,
       })
     }
   },
+  "bgpconf.edit": {
+    on({ store, detail, success, ...props }) {
+      const formTemplate = FORM_TEMPLATES['bgpconf']()
+      const modal = Modal.open({
+        onOk: (data) => {
+          store.patchConf(data).then(() => {
+            Modal.close(modal)
+            Notify.success({ content: "Updated successfully." })
+            success && success()
+          })
+        },
+        modal: CreateBgpConfModel,
+        formModal: formBgpConfModel,
+        name: 'BgpConf',
+        formTemplate,
+        detail,
+        store,
+        ...props,
+      })
+    }
+  }
 }
 
 export default Actions

--- a/src/actions/BGP.js
+++ b/src/actions/BGP.js
@@ -1,10 +1,31 @@
-import CommonAction from "./base";
+import Modal from "../components/Base/Modal"
+import createModal from "../components/Modal/Create"
+import CommonAction from "./base"
+import steps from "../steps/bgppeer"
+import FORM_TEMPLATES from "../utils/form.templates"
 
 const Actions = {
   ...CommonAction,
+  "bgp.create": {
+    on({ store }) {
+      const formTemplate = FORM_TEMPLATES['bgp']()
+      const modal = Modal.open({
+        onOk: (formData) => {
+          // TODO
+          // need to implement the create action in eip Store
+        },
+        modal: createModal,
+        steps,
+        name: 'BgpPeer',
+        formTemplate,
+        store,
+        okBtnText: 'create',
+      })
+    }
+  },
   "bgp.editInfo": {
     on() {
-      console.log('bgp editInfo');
+      console.log('bgp editInfo')
     }
   }
 }

--- a/src/actions/base.js
+++ b/src/actions/base.js
@@ -1,18 +1,82 @@
+import { Notify } from '@kube-design/components'
+import Modal from '../components/Base/Modal'
+import DeleteModal from "../components/Modal/Delete"
+import EditBaseInfoModal from '../components/Modal/EditBaseInfo'
+
 const CommonAction = {
   "resource.delete": {
-    on() {
-      console.log('delete me');
-    }
+    on({ store, detail, success, ...props }) {
+      const modal = Modal.open({
+        onOk: () => {
+          store.delete(detail).then(() => {
+            Modal.close(modal)
+            Notify.success({ content: "Deleted successfully." })
+            success && success()
+          })
+        },
+        store,
+        modal: DeleteModal,
+        resource: detail.name,
+        ...props,
+      })
+    },
   },
   "resource.baseinfo.edit": {
-    on({ success }) {
-      console.log('resource.baseinfo.edit', success());
-    }
+    on({ store, detail, success, ...props }) {
+      const modal = Modal.open({
+        onOk: data => {
+          store.patch(detail, data).then(() => {
+            Modal.close(modal)
+            Notify.success({ content: "Updated successfully." })
+            success && success()
+          })
+        },
+        detail,
+        modal: EditBaseInfoModal,
+        store,
+        ...props,
+      })
+    },
   },
   "resource.batch.delete": {
-    on(props) {
-      console.log('batch delete', props);
-    }
+    on({ store, success, rowKey, ...props }) {
+      const { data, selectedRowKeys } = store.list
+      const selectValues = data
+        .filter(item => selectedRowKeys.includes(item[rowKey]))
+        .map(item => {
+          return { name: item.name, namespace: item.namespace }
+        })
+
+      const selectNames = selectValues.map(item => item.name)
+
+      const modal = Modal.open({
+        onOk: async () => {
+          const reqs = []
+
+          data.forEach(item => {
+            const selectValue = selectValues.find(
+              value =>
+                value.name === item.name && value.namespace === item.namespace
+            )
+
+            if (selectValue) {
+              reqs.push(store.delete(item))
+            }
+          })
+
+          await Promise.all(reqs)
+
+          Modal.close(modal)
+          Notify.success({ content: "Deleted successfully." })
+          store.setSelectRowKeys([])
+          success && success()
+        },
+        resource: selectNames.join(', '),
+        modal: DeleteModal,
+        store,
+        ...props,
+      })
+    },
   }
 }
 

--- a/src/actions/eip.js
+++ b/src/actions/eip.js
@@ -1,26 +1,64 @@
+import { Notify } from '@kube-design/components'
 import Modal from '../components/Base/Modal'
 import createModal from '../components/Modal/Create'
-
-import CommonAction from "./base";
-import steps from '../steps/eip';
+import viewYAMLModal from "../components/Modal/EditYAML.jsx"
+import CommonAction from "./base"
+import steps from '../steps/eip'
 import FORM_TEMPLATES from '../utils/form.templates'
+import disableEIPModal from "../components/Modal/DisableEIP"
 
 const Actions = {
   ...CommonAction,
   "eip.create": {
-    on({ store }) {
+    on({ store, success, ...props }) {
       const formTemplate = FORM_TEMPLATES['eip']()
       const modal = Modal.open({
         onOk: (formData) => {
-          // TODO
-          // need to implement the create action in eip Store
+          store.create(formData).then(() => {
+            Modal.close(modal)
+            Notify.success({ content: "Created successfully." })
+            success && success()
+          })
         },
         modal: createModal,
         steps,
         name: 'EIP',
         formTemplate,
         store,
-        okBtnText: 'create',
+        okBtnText: 'Create',
+        ...props,
+      })
+    }
+  },
+  "eip.yaml.view": {
+    on({ detail, success, ...props }) {
+      Modal.open({
+        detail,
+        modal: viewYAMLModal,
+        title: 'View YAML',
+        readOnly: true,
+        ...props,
+      })
+    }
+  },
+  "eip.disable": {
+    on({ store, detail, success, ...props }) {
+      const modal = Modal.open({
+        onOk: (data) => {
+          store.patch(detail, data).then(() => {
+            Modal.close(modal)
+            Notify.success({
+              content:
+                `${detail.disable ? 'Enabled' : 'Disabled'} successfully.`
+            })
+            success && success()
+          })
+        },
+        modal: disableEIPModal,
+        detail,
+        store,
+        resource: detail.name,
+        ...props,
       })
     }
   }

--- a/src/components/Base/Modal/form.jsx
+++ b/src/components/Base/Modal/form.jsx
@@ -65,7 +65,7 @@ export default class ModalForm extends React.Component {
                 onClick={onCancel}
                 data-test="modal-cancel"
               >
-                {cancelText || t('CANCEL')}
+                {cancelText || 'Cancel'}
               </Button>
               <Button
                 type="control"
@@ -74,7 +74,7 @@ export default class ModalForm extends React.Component {
                 disabled={disableOk || isSubmitting}
                 data-test="modal-ok"
               >
-                {okText || t('OK')}
+                {okText || 'Ok'}
               </Button>
             </div>
           )}

--- a/src/components/Cards/Info/index.jsx
+++ b/src/components/Cards/Info/index.jsx
@@ -1,37 +1,68 @@
 import { Component } from "react"
 import moment from "moment"
-import { Dropdown, Icon, Menu } from "@kube-design/components"
+import { Button, Dropdown, Icon, Menu } from "@kube-design/components"
 import styles from "./index.module.scss"
+import { inject } from "mobx-react"
+import { trigger } from "../../../utils/action"
 
 class Info extends Component {
   get detail() {
     return this.props.detail
   }
 
+  get routing() {
+    return this.props.rootStore.routing
+  }
+
+  get name() {
+    return "EIP"
+  }
+
+  get eip() {
+    return this.props.eip
+  }
+
+  get store() {
+    return this.props.store
+  }
+
+  async fetchData() {
+    await this.store.fetchDetail({ name: this.eip })
+  }
+
   handleBackButtonClick() {
-    this.props.routing.push("/eip")
+    this.routing.push("/eip")
   }
 
   handleMoreMenuItemClick(e, key, value, isEnabled) {
     switch (key) {
       case "disable":
-        this.props.store.patch({ name: this.detail.name },
-          {
-            spec: {
-              disable: isEnabled
-            }
-          })
-        window.setTimeout(() => this.props.store.fetchDetail({
-          name: this.detail.name
-        }), 100)
+        this.trigger('eip.disable', {
+          type: this.name,
+          detail: this.detail,
+          success: this.fetchData.bind(this),
+          store: this.store
+        })
         break
       case "delete":
-        this.props.store.delete({ name: this.detail.name })
-        window.setTimeout(() => this.props.routing.push("/eip"), 100)
+        this.trigger('resource.delete', {
+          type: this.name,
+          resource: this.eip,
+          detail: this.detail,
+          store: this.store,
+          success: () => this.routing.push("/eip"),
+        })
         break
       default:
         break
     }
+  }
+
+  handleYAMLButtonClick() {
+    this.trigger('eip.yaml.view', {
+      detail: this.detail,
+      store: this.store,
+    })
   }
 
   detailsKeys() {
@@ -103,11 +134,11 @@ class Info extends Component {
         </div>
 
         <div className={styles.buttongroup}>
-          <button>View YAML</button>
+          <Button onClick={this.handleYAMLButtonClick.bind(this)}>View YAML</Button>
           <Dropdown theme="dark" content={this.renderMoreMenu.bind(this)} >
-            <button>
-              <p>More</p>
-              <Icon name="caret-down" size={16} /></button>
+            <Button>
+              More
+              <Icon name="caret-down" size={16} /></Button>
           </Dropdown>
         </div>
       </div>
@@ -136,4 +167,4 @@ class Info extends Component {
   }
 }
 
-export default Info
+export default inject("rootStore")(trigger(Info))

--- a/src/components/Cards/Info/index.module.scss
+++ b/src/components/Cards/Info/index.module.scss
@@ -78,19 +78,6 @@
       display: flex;
       flex-direction: row;
       align-items: flex-start;
-      gap: 12px;
-
-      &>button {
-        display: flex;
-        flex-direction: row;
-        justify-content: center;
-        align-items: center;
-        gap: 4px;
-        background-color: $light-color02;
-        border: 1px solid $light-color06;
-        border-radius: 16px;
-        padding: 6px 24px;
-      }
     }
   }
 

--- a/src/components/Cards/Info/index.module.scss
+++ b/src/components/Cards/Info/index.module.scss
@@ -20,6 +20,7 @@
     background-image: url(../../../assets/info-background.svg);
 
     .itemtext {
+      font-family: 'PingFang SC';
       font-weight: 600;
       font-size: 12px;
       line-height: 20px;
@@ -36,6 +37,7 @@
       border-radius: 100px;
 
       &>p {
+        font-family: 'PingFang SC';
         font-weight: 600;
         line-height: 20px;
         font-size: 12px;
@@ -49,6 +51,7 @@
       gap: 8px;
 
       &>p {
+        font-family: 'PingFang SC';
         font-weight: 600;
         font-size: 20px;
         line-height: 28px;
@@ -62,6 +65,7 @@
         border-radius: 2px;
 
         &>p {
+          font-family: 'PingFang SC';
           font-weight: 600;
           font-size: 12px;
           line-height: 20px;
@@ -99,6 +103,7 @@
     width: 100%;
 
     &>p {
+      font-family: 'PingFang SC';
       font-weight: 600;
       font-size: 12px;
       line-height: 20px;
@@ -119,6 +124,7 @@
         flex-grow: 1;
 
         .keytext {
+          font-family: 'PingFang SC';
           font-weight: 400;
           font-size: 12px;
           line-height: 20px;
@@ -126,6 +132,7 @@
         }
 
         .valuetext {
+          font-family: 'PingFang SC';
           font-weight: 400;
           font-size: 12px;
           line-height: 20px;
@@ -147,6 +154,7 @@
             gap: 4px;
 
             &>p {
+              font-family: 'PingFang SC';
               font-weight: 600;
               font-size: 12px;
               line-height: 20px;

--- a/src/components/Forms/BGPConf/index.jsx
+++ b/src/components/Forms/BGPConf/index.jsx
@@ -1,0 +1,58 @@
+import React from "react"
+import { Column, Columns, Form, Input } from "@kube-design/components"
+import NumberInput from "../../NumberInput"
+
+class BgpConfSettings extends React.Component {
+  render() {
+    const { formRef, formTemplate } = this.props
+
+    return (
+      <Form
+        {...this.props}
+        ref={formRef}
+        data={formTemplate}
+      >
+        <Columns>
+          <Column>
+            <Form.Item
+              label="Name"
+              desc="OpenELB recognizes only the name default. BgpConf objects with other names will be ignored."
+            >
+              <Input name="metadata.name" disabled />
+            </Form.Item>
+          </Column>
+          <Column>
+            <Form.Item
+              label="ASN"
+              desc="Local ASN, which must be different from the value of spec:conf:peerAS in the BgpPeer configuration."
+              rules={[{ required: true, message: 'ASN is required.' }]}
+            >
+              <NumberInput name="spec.as" min={0} />
+            </Form.Item>
+          </Column>
+        </Columns>
+        <Columns>
+          <Column>
+            <Form.Item
+              label="ListenPort"
+              desc="The default value is 179 (default BGP port number). If other components (such as Calico) in the Kubernetes cluster also use BGP and port 179, you must set a different value to avoid the conflict."
+              rules={[{ required: true, message: 'ListenPort is required.' }]}
+            >
+              <NumberInput name="spec.listenPort" min={0} />
+            </Form.Item>
+          </Column>
+          <Column>
+            <Form.Item
+              label="RouterID"
+              desc="Local router ID, which is usually set to the IP address of the master NIC of the Kubernetes master node. If this field is not specified, the first IP address of the node where openelb-manager is located will be used."
+            >
+              <Input name="spec.routerId" />
+            </Form.Item>
+          </Column>
+        </Columns>
+      </Form>
+    )
+  }
+}
+
+export default BgpConfSettings

--- a/src/components/Forms/BGPPeer/BaseInfo/index.jsx
+++ b/src/components/Forms/BGPPeer/BaseInfo/index.jsx
@@ -1,0 +1,56 @@
+import React from 'react'
+import { observer } from 'mobx-react'
+import { Form, Columns, Column, Input, TextArea } from '@kube-design/components'
+
+const BgpPeerBaseInfo = observer(
+  class BgpPeerBaseInfo extends React.Component {
+    render() {
+      const { formTemplate, formRef } = this.props
+
+      return (
+        <Form data={formTemplate} ref={formRef}>
+          <Columns>
+            <Column>
+              <Form.Item
+                label="Name"
+                desc={
+                  "The name can contain only lowercase letters, numbers, and hyphens (-), must start with a lowercase letter, and must end with a lowercase letter or number. The maximum length is 63 characters."
+                }
+                rules={[{ required: true, message: 'Name is required.' }]}
+              >
+                <Input name="metadata.name" />
+              </Form.Item>
+            </Column>
+            <Column>
+              <Form.Item
+                label="Alias"
+                desc={
+                  "The alias can contain any characters and the maximum length is 63 characters."
+                }
+              >
+                <Input name="annotations['openelb.io/alias']" />
+              </Form.Item>
+            </Column>
+          </Columns>
+          <Columns>
+            <Column>
+              <Form.Item
+                label={"Description"}
+                desc={
+                  "The description can contain any characters and the maximum length is 256 characters."
+                }
+              >
+                <TextArea
+                  name="metadata.annotations['openelb.io/description']"
+                  maxLength={256}
+                />
+              </Form.Item>
+            </Column>
+          </Columns>
+        </Form>
+      )
+    }
+  }
+)
+
+export default BgpPeerBaseInfo

--- a/src/components/Forms/BGPPeer/Settings/index.jsx
+++ b/src/components/Forms/BGPPeer/Settings/index.jsx
@@ -1,0 +1,54 @@
+import React from 'react'
+import { observer } from 'mobx-react'
+import { Form, Columns, Column, Input } from '@kube-design/components'
+
+const SendMaxDesc = "Maximum number of equivalent routes that OpenELB can send to the peer BGP router for Equal-Cost Multi-Path (ECMP) routing. The default value is 10."
+
+class BgpPeerSettings extends React.Component {
+
+  render() {
+    const { formRef, formTemplate } = this.props
+
+    return (
+      <Form data={formTemplate} ref={formRef}>
+        <Columns>
+          <Column>
+            <Form.Item
+              label="Peer AS"
+              rules={[{ required: true, message: 'Peer AS is required.' }]}
+            >
+              <Input name="spec.conf.peerAs" />
+            </Form.Item>
+          </Column>
+          <Column>
+            <Form.Item
+              label="Neighbor Address"
+              rules={[{ required: true, message: 'Neighbor Address is required.' }]}
+            >
+              <Input name="spec.conf.neighborAddress" />
+            </Form.Item>
+          </Column>
+        </Columns>
+        <Columns>
+          <Column>
+            <Form.Item
+              label="SendMax"
+              desc={SendMaxDesc}
+            >
+              <Input name="spec.afiSafis[0].addPaths.config.sendMax" />
+            </Form.Item>
+          </Column>
+          <Column>
+            <Form.Item
+              label="BgpPeer Leaf"
+            >
+              <Input name="spec.nodeSelector.matchLabels['openelb.kubesphere.io/rack']" />
+            </Form.Item>
+          </Column>
+        </Columns>
+      </Form>
+    )
+  }
+}
+
+export default observer(BgpPeerSettings)

--- a/src/components/Forms/BGPPeer/Settings/index.jsx
+++ b/src/components/Forms/BGPPeer/Settings/index.jsx
@@ -3,12 +3,11 @@ import { observer } from 'mobx-react'
 import { Form, Columns, Column, Input } from '@kube-design/components'
 import NumberInput from "../../../NumberInput"
 
-const SendMaxDesc = "Maximum number of equivalent routes that OpenELB can send to the peer BGP router for Equal-Cost Multi-Path (ECMP) routing. The default value is 10."
-
 class BgpPeerSettings extends React.Component {
 
   render() {
     const { formRef, formTemplate } = this.props
+    const SendMaxDesc = "Maximum number of equivalent routes that OpenELB can send to the peer BGP router for Equal-Cost Multi-Path (ECMP) routing. The default value is 10."
 
     return (
       <Form data={formTemplate} ref={formRef}>

--- a/src/components/Forms/BGPPeer/Settings/index.jsx
+++ b/src/components/Forms/BGPPeer/Settings/index.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { observer } from 'mobx-react'
 import { Form, Columns, Column, Input } from '@kube-design/components'
+import NumberInput from "../../../NumberInput"
 
 const SendMaxDesc = "Maximum number of equivalent routes that OpenELB can send to the peer BGP router for Equal-Cost Multi-Path (ECMP) routing. The default value is 10."
 
@@ -17,7 +18,7 @@ class BgpPeerSettings extends React.Component {
               label="Peer AS"
               rules={[{ required: true, message: 'Peer AS is required.' }]}
             >
-              <Input name="spec.conf.peerAs" type="number" />
+              <NumberInput name="spec.conf.peerAs" min={0} />
             </Form.Item>
           </Column>
           <Column>
@@ -35,7 +36,7 @@ class BgpPeerSettings extends React.Component {
               label="SendMax"
               desc={SendMaxDesc}
             >
-              <Input name="spec.afiSafis[0].addPaths.config.sendMax" type="number" />
+              <NumberInput name="spec.afiSafis[0].addPaths.config.sendMax" min={0} />
             </Form.Item>
           </Column>
           <Column>

--- a/src/components/Forms/BGPPeer/Settings/index.jsx
+++ b/src/components/Forms/BGPPeer/Settings/index.jsx
@@ -17,7 +17,7 @@ class BgpPeerSettings extends React.Component {
               label="Peer AS"
               rules={[{ required: true, message: 'Peer AS is required.' }]}
             >
-              <Input name="spec.conf.peerAs" />
+              <Input name="spec.conf.peerAs" type="number" />
             </Form.Item>
           </Column>
           <Column>
@@ -35,7 +35,7 @@ class BgpPeerSettings extends React.Component {
               label="SendMax"
               desc={SendMaxDesc}
             >
-              <Input name="spec.afiSafis[0].addPaths.config.sendMax" />
+              <Input name="spec.afiSafis[0].addPaths.config.sendMax" type="number" />
             </Form.Item>
           </Column>
           <Column>

--- a/src/components/Forms/EIP/BaseInfo/index.jsx
+++ b/src/components/Forms/EIP/BaseInfo/index.jsx
@@ -27,9 +27,8 @@ const EipBaseInfo = observer(
                 desc={
                   "The alias can contain any characters and the maximum length is 63 characters."
                 }
-                rules={[{ required: true, message: 'Alias is required.' }]}
               >
-                <Input name="annotations['kubesphere.io/alias']" />
+                <Input name="annotations['openelb.io/alias']" />
               </Form.Item>
             </Column>
           </Columns>
@@ -42,7 +41,7 @@ const EipBaseInfo = observer(
                 }
               >
                 <TextArea
-                  name="metadata.annotations['kubesphere.io/description']"
+                  name="metadata.annotations['openelb.io/description']"
                   maxLength={256}
                 />
               </Form.Item>

--- a/src/components/Forms/EIP/Settings/index.jsx
+++ b/src/components/Forms/EIP/Settings/index.jsx
@@ -5,14 +5,14 @@ import { get, set } from 'lodash'
 
 import styles from './index.module.scss'
 import IPSelect from './IPSelect'
-const IPDesc = "One or more IP addresses, which will be used by OpenELB，The value format can be like IP 、IP/Subnet mask、IP segment."
+const IPDesc = "One or more IP addresses, which will be used by OpenELB, The value format can be like IP 、IP/Subnet mask、IP segment."
 
 class EipSettings extends React.Component {
   constructor(props) {
     super(props)
-    console.log(props);
     this.state = {
       ipType: 'IP',
+      protocol: 'bgp',
       address: get(props.formTemplate, 'spec.address'),
       isDefault: get(props.formTemplate, "metadata.annotation['eip.openelb.kubesphere.io/is-default-eip']", false),
       disable: get(props.formTemplate, 'spec.disable', false),
@@ -39,9 +39,15 @@ class EipSettings extends React.Component {
     })
   }
 
+  handleProtocolChange = (value) => {
+    this.setState({
+      protocol: value
+    })
+  }
+
   render() {
     const { formRef, formTemplate } = this.props
-    const { isDefault, disable } = this.state
+    const { isDefault, disable, protocol } = this.state
 
     return (
       <Form data={formTemplate} ref={formRef}>
@@ -80,8 +86,9 @@ class EipSettings extends React.Component {
                     value: 'vip'
                   },
                 ]}
-                defaultValue={'layer2'}
-              // placeholder={""}
+                defaultValue={'bgp'}
+                onChange={this.handleProtocolChange}
+                placeholder="Select Protocol"
               />
             </Form.Item>
           </Column>
@@ -89,7 +96,7 @@ class EipSettings extends React.Component {
             <Form.Item
               label={"Interface"}
               desc={"NIC on which OpenELB listens for ARP or NDP requests. "}
-              rules={[{ required: true, message: 'Interface is required.' }]}
+              rules={[{ required: protocol !== 'bgp', message: 'Interface is required.' }]}
             >
               <Input name={"spec.interface"} />
             </Form.Item>
@@ -117,7 +124,7 @@ class EipSettings extends React.Component {
               {"Disable EIP"}
             </p>
             <p className={styles.des}>
-              {"If EIP is disabled，OpenELB will stop assigning IP addresses in the EIP object to new LoadBalancer Services. Existing Services are not affected."}
+              {"If EIP is disabled, OpenELB will stop assigning IP addresses in the EIP object to new LoadBalancer Services. Existing Services are not affected."}
             </p>
           </div>
         </div>

--- a/src/components/Lists/Service/index.module.scss
+++ b/src/components/Lists/Service/index.module.scss
@@ -8,6 +8,7 @@
   align-self: stretch;
 
   &>p {
+    font-family: 'PingFang SC';
     font-weight: 600;
     font-size: 12px;
     line-height: 20px;
@@ -47,6 +48,7 @@
         border-radius: 4px;
 
         .valuetext {
+          font-family: 'PingFang SC';
           font-weight: 600;
           font-size: 12px;
           line-height: 20px;
@@ -54,6 +56,7 @@
         }
 
         .keytext {
+          font-family: 'PingFang SC';
           font-weight: 400;
           font-size: 12px;
           line-height: 20px;

--- a/src/components/Modal/BgpConfCreate/index.jsx
+++ b/src/components/Modal/BgpConfCreate/index.jsx
@@ -8,6 +8,7 @@ import Code from '../Create/Code'
 
 import styles from './index.module.scss'
 import { observer } from "mobx-react"
+import NumberInput from "../../NumberInput"
 
 class CreateModal extends React.Component {
   static propTypes = {
@@ -110,8 +111,7 @@ class CreateModal extends React.Component {
                   label="Name"
                   desc="OpenELB recognizes only the name default. BgpConf objects with other names will be ignored."
                 >
-                  <Input name="metadata.name"
-                    style={{ backgroundColor: "#EFF4F9" }} />
+                  <Input name="metadata.name" disabled />
                 </Form.Item>
               </Column>
               <Column>
@@ -120,7 +120,7 @@ class CreateModal extends React.Component {
                   desc="Local ASN, which must be different from the value of spec:conf:peerAS in the BgpPeer configuration."
                   rules={[{ required: true, message: 'ASN is required.' }]}
                 >
-                  <Input name="spec.as" type="number" />
+                  <NumberInput name="spec.as" min={0} />
                 </Form.Item>
               </Column>
             </Columns>
@@ -131,7 +131,7 @@ class CreateModal extends React.Component {
                   desc="The default value is 179 (default BGP port number). If other components (such as Calico) in the Kubernetes cluster also use BGP and port 179, you must set a different value to avoid the conflict."
                   rules={[{ required: true, message: 'ListenPort is required.' }]}
                 >
-                  <Input name="spec.listenPort" type="number" />
+                  <NumberInput name="spec.listenPort" min={0} />
                 </Form.Item>
               </Column>
               <Column>

--- a/src/components/Modal/BgpConfCreate/index.jsx
+++ b/src/components/Modal/BgpConfCreate/index.jsx
@@ -1,0 +1,211 @@
+import { get, isFunction, cloneDeep, isArray, omit } from 'lodash'
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Form, Columns, Column, Input } from '@kube-design/components'
+import Modal from '../../Base/Modal'
+import Switch from '../../Base/Switch'
+import Code from '../Create/Code'
+
+import styles from './index.module.scss'
+import { observer } from "mobx-react"
+
+class CreateModal extends React.Component {
+  static propTypes = {
+    title: PropTypes.string,
+    name: PropTypes.string,
+    module: PropTypes.string,
+    steps: PropTypes.array,
+    store: PropTypes.object,
+    formTemplate: PropTypes.object,
+    visible: PropTypes.bool,
+    okBtnText: PropTypes.string, // not requried
+    onOk: PropTypes.func,
+    onCancel: PropTypes.func,
+    noCodeEdit: PropTypes.bool,
+    isSubmitting: PropTypes.bool,
+  }
+
+  static defaultProps = {
+    visible: false,
+    noCodeEdit: false,
+    isSubmitting: false,
+    onOk() { },
+    onCancel() { },
+  }
+
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      formTemplate: cloneDeep(props.formTemplate),
+      isCodeMode: props.onlyCode || false,
+    }
+
+    this.codeRef = React.createRef()
+    this.formRef = React.createRef()
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.visible !== prevProps.visible) {
+      if (this.props.visible) {
+        this.setState({
+          isCodeMode: this.props.onlyCode || false,
+          formTemplate: cloneDeep(this.props.formTemplate),
+        })
+      }
+    }
+  }
+
+  getFormDataFromCode = code =>
+    isArray(code)
+      ? code.reduce(
+        (prev, cur) => ({
+          ...prev,
+          [cur.kind.replace('Federated', '')]: cur,
+        }),
+        {}
+      )
+      : code
+
+  handleModeChange = () => {
+    this.setState(({ isCodeMode, formTemplate }) => {
+      const kind = Object.keys(formTemplate)[0]
+      const omitArr = [
+        `${kind}.spec.template.totalReplicas`,
+        'totalReplicas',
+        `${kind}.totalReplicas`,
+      ]
+      formTemplate = omit(formTemplate, omitArr)
+      const newState = { formTemplate, isCodeMode: !isCodeMode }
+
+      if (isCodeMode && isFunction(get(this, 'codeRef.current.getData'))) {
+        newState.formTemplate = this.getFormDataFromCode(
+          this.codeRef.current.getData()
+        )
+      }
+
+      return newState
+    })
+  }
+
+  handleCode = data => {
+    const { onOk } = this.props
+    onOk(this.getFormDataFromCode(data))
+  }
+
+  renderForms() {
+    const { formTemplate } = this.state
+
+    return (
+      <div className={styles.contentWrapper}>
+        <div className={styles.content}>
+          <Form
+            {...this.props}
+            ref={this.formRef}
+            data={formTemplate}
+          >
+            <Columns>
+              <Column>
+                <Form.Item
+                  label="Name"
+                  desc="OpenELB recognizes only the name default. BgpConf objects with other names will be ignored."
+                >
+                  <Input name="metadata.name"
+                    style={{ backgroundColor: "#EFF4F9" }} />
+                </Form.Item>
+              </Column>
+              <Column>
+                <Form.Item
+                  label="ASN"
+                  desc="Local ASN, which must be different from the value of spec:conf:peerAS in the BgpPeer configuration."
+                  rules={[{ required: true, message: 'ASN is required.' }]}
+                >
+                  <Input name="spec.as" type="number" />
+                </Form.Item>
+              </Column>
+            </Columns>
+            <Columns>
+              <Column>
+                <Form.Item
+                  label="ListenPort"
+                  desc="The default value is 179 (default BGP port number). If other components (such as Calico) in the Kubernetes cluster also use BGP and port 179, you must set a different value to avoid the conflict."
+                  rules={[{ required: true, message: 'ListenPort is required.' }]}
+                >
+                  <Input name="spec.listenPort" type="number" />
+                </Form.Item>
+              </Column>
+              <Column>
+                <Form.Item
+                  label="RouterID"
+                  desc="Local router ID, which is usually set to the IP address of the master NIC of the Kubernetes master node. If this field is not specified, the first IP address of the node where openelb-manager is located will be used."
+                >
+                  <Input name="spec.routerId" />
+                </Form.Item>
+              </Column>
+            </Columns>
+          </Form>
+        </div>
+      </div>
+    )
+  }
+
+  renderCodeEditor() {
+    const { onCancel, isSubmitting } = this.props
+    const { formTemplate } = this.state
+    return (
+      <Code
+        ref={this.codeRef}
+        formTemplate={formTemplate}
+        onOk={this.handleCode}
+        onCancel={onCancel}
+        isSubmitting={isSubmitting}
+        hideFooter={true}
+      />
+    )
+  }
+
+  renderOperations() {
+    const { noCodeEdit, onlyCode } = this.props
+    const { isCodeMode } = this.state
+
+    if (noCodeEdit || onlyCode) {
+      return null
+    }
+
+    return (
+      <Switch
+        className={styles.switch}
+        text={'Edit YAML'}
+        onChange={this.handleModeChange}
+        checked={isCodeMode}
+      />
+    )
+  }
+
+  render() {
+    const { name, width, visible, onCancel, noCodeEdit, ...rest } = this.props
+    const { isCodeMode } = this.state
+
+    const title = this.props.title || `Create ${name}`
+
+    return (
+      <Modal
+        width={width || 960}
+        title={title}
+        bodyClassName={styles.body}
+        onCancel={onCancel}
+        visible={visible}
+        {...rest}
+        operations={this.renderOperations()}
+        okText="Create"
+        footerClassName={styles.footer}
+      >
+        {!noCodeEdit && isCodeMode
+          ? this.renderCodeEditor()
+          : this.renderForms()}
+      </Modal>
+    )
+  }
+}
+
+export default observer(CreateModal)

--- a/src/components/Modal/BgpConfCreate/index.module.scss
+++ b/src/components/Modal/BgpConfCreate/index.module.scss
@@ -41,8 +41,6 @@
 
 .footer {
   padding: 12px 20px;
-  background-color: $light-color02;
-  box-shadow: inset 0px 1px 0px #CCD3DB;
-  border-radius: 0px 0px 4px 4px;
+  background-color: $bg-color;
   text-align: right;
 }

--- a/src/components/Modal/BgpConfCreate/index.module.scss
+++ b/src/components/Modal/BgpConfCreate/index.module.scss
@@ -1,0 +1,48 @@
+@import '/src/scss/variables';
+@import '/src/scss/mixins';
+
+.body {
+  overflow: hidden;
+  max-height: none;
+  padding: 0;
+}
+
+.switch {
+  position: absolute !important;
+  top: 50%;
+  right: 72px;
+  transform: translateY(-50%);
+  background-color: $light-color04;
+}
+
+.close {
+  position: absolute;
+  @include vertical-center;
+  right: 20px;
+  width: 32px;
+  height: 32px;
+  padding: 6px;
+  border-radius: $border-radius;
+  background-color: #242e42;
+  cursor: pointer;
+}
+
+.contentWrapper {
+  min-height: 500px;
+  max-height: calc(100vh - 222px);
+  overflow-y: auto;
+}
+
+.content {
+  width: 920px;
+  margin: 0 auto;
+  padding: 20px 0 48px 0;
+}
+
+.footer {
+  padding: 12px 20px;
+  background-color: $light-color02;
+  box-shadow: inset 0px 1px 0px #CCD3DB;
+  border-radius: 0px 0px 4px 4px;
+  text-align: right;
+}

--- a/src/components/Modal/Create/Code/index.jsx
+++ b/src/components/Modal/Create/Code/index.jsx
@@ -29,11 +29,13 @@ export default class CodeMode extends React.Component {
     formTemplate: PropTypes.object,
     onOk: PropTypes.func,
     isSubmitting: PropTypes.bool,
+    hideFooter: PropTypes.bool,
   }
 
   static defaultProps = {
     onOk() {},
     isSubmitting: false,
+    hideFooter: false,
   }
 
   constructor(props) {
@@ -52,13 +54,13 @@ export default class CodeMode extends React.Component {
   }
 
   render() {
-    const { formTemplate, onCancel, isSubmitting } = this.props
+    const { formTemplate, onCancel, isSubmitting, hideFooter } = this.props
     return (
       <div>
         <div className={styles.wrapper}>
           <EditMode ref={this.editor} value={formTemplate} />
         </div>
-        <div className={styles.footer}>
+        {!hideFooter? <div className={styles.footer}>
           <Button onClick={onCancel}>{'Cancel'}</Button>
           <Button
             type="control"
@@ -68,7 +70,7 @@ export default class CodeMode extends React.Component {
           >
             {'Create'}
           </Button>
-        </div>
+        </div> : <></>}
       </div>
     )
   }

--- a/src/components/Modal/Create/Code/index.jsx
+++ b/src/components/Modal/Create/Code/index.jsx
@@ -30,12 +30,16 @@ export default class CodeMode extends React.Component {
     onOk: PropTypes.func,
     isSubmitting: PropTypes.bool,
     hideFooter: PropTypes.bool,
+    okText: PropTypes.string,
+    readOnly: PropTypes.bool,
   }
 
   static defaultProps = {
-    onOk() {},
+    onOk() { },
     isSubmitting: false,
     hideFooter: false,
+    okText: 'Create',
+    readOnly: false
   }
 
   constructor(props) {
@@ -54,13 +58,13 @@ export default class CodeMode extends React.Component {
   }
 
   render() {
-    const { formTemplate, onCancel, isSubmitting, hideFooter } = this.props
+    const { formTemplate, onCancel, isSubmitting, hideFooter, okText, readOnly } = this.props
     return (
       <div>
         <div className={styles.wrapper}>
-          <EditMode ref={this.editor} value={formTemplate} />
+          <EditMode ref={this.editor} value={formTemplate} readOnly={readOnly} />
         </div>
-        {!hideFooter? <div className={styles.footer}>
+        {!hideFooter && !readOnly ? <div className={styles.footer}>
           <Button onClick={onCancel}>{'Cancel'}</Button>
           <Button
             type="control"
@@ -68,7 +72,7 @@ export default class CodeMode extends React.Component {
             loading={isSubmitting}
             disabled={isSubmitting}
           >
-            {'Create'}
+            {okText}
           </Button>
         </div> : <></>}
       </div>

--- a/src/components/Modal/Delete/index.jsx
+++ b/src/components/Modal/Delete/index.jsx
@@ -1,0 +1,135 @@
+
+/* This file is part of KubeSphere Console.
+* Copyright (C) 2019 The KubeSphere Console Authors.
+*
+* KubeSphere Console is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* KubeSphere Console is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with KubeSphere Console.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import { Button, Icon, Input } from '@kube-design/components'
+import Modal from '../../Base/Modal'
+
+import styles from './index.module.scss'
+
+export default class DeleteModal extends React.Component {
+  static propTypes = {
+    type: PropTypes.string,
+    resource: PropTypes.string,
+    visible: PropTypes.bool,
+    title: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+    desc: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+    onOk: PropTypes.func,
+    onCancel: PropTypes.func,
+    isSubmitting: PropTypes.bool,
+  }
+
+  static defaultProps = {
+    visible: false,
+    isSubmitting: false,
+    onOk() { },
+    onCancel() { },
+  }
+
+  state = {
+    confirm: '',
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.visible && this.props.visible !== prevProps.visible) {
+      this.setState({ confirm: '' })
+    }
+  }
+
+  handleInputChange = e => {
+    this.setState({ confirm: e.target.value })
+  }
+
+  handleOk = () => {
+    this.props.onOk()
+  }
+
+  tip(type, resource) {
+    return `Enter ${type ? `the ${type} name ` : ''}${resource} to confirm that you understand the risks of this operation.`
+  }
+
+  render() {
+    const {
+      type,
+      resource,
+      visible,
+      onCancel,
+      title,
+      desc,
+      isSubmitting
+    } = this.props
+    const typeKey = type || undefined
+    const typeKeyLow = type ? type.toLowerCase() : undefined
+
+    const isMutiple = resource.split(", ").length !== 1
+    let tip = desc || `Enter the ${type ? `${typeKeyLow} ` : ''}${isMutiple? 'names': 'name'} ${resource} to confirm that you understand the risks of this operation.`
+    
+    return (
+      <Modal
+        width={504}
+        bodyClassName={styles.modalBody}
+        visible={visible}
+        isSubmitting={isSubmitting}
+        onCancel={onCancel}
+        hideHeader
+        hideFooter
+      >
+        <div className={styles.body}>
+          <div className="h5">
+            <Icon name="close" type="light" className={styles.closeIcon} />
+            {title ||
+              (resource && type
+                ? isMutiple ? `Delete Mutiple ${typeKey}` : `Delete ${typeKey}`
+                : 'Delete')}
+          </div>
+          <div className={styles.content}>
+            <p>{tip}</p>
+            {resource && (
+              <Input
+                name="confirm"
+                value={this.state.confirm}
+                onChange={this.handleInputChange}
+                placeholder={resource}
+                autoFocus={true}
+              />
+            )}
+          </div>
+        </div>
+        <div className={styles.footer}>
+          <Button onClick={onCancel} data-test="modal-cancel">
+            Cancel
+          </Button>
+          <Button
+            type="danger"
+            loading={isSubmitting}
+            disabled={
+              isSubmitting ||
+              (resource ? this.state.confirm !== resource : false)
+            }
+            onClick={this.handleOk}
+            data-test="modal-ok"
+          >
+            OK
+          </Button>
+        </div>
+      </Modal>
+    )
+  }
+}

--- a/src/components/Modal/Delete/index.module.scss
+++ b/src/components/Modal/Delete/index.module.scss
@@ -1,0 +1,65 @@
+@import '/src/scss/variables';
+
+.modalBody {
+  padding: 0;
+}
+
+.body {
+  padding: 12px;
+
+  :global {
+    .h5 {
+      font-size: $size-normal;
+      font-weight: $font-bold;
+      line-height: 20px;
+      color: $title-color;
+    }
+
+    p {
+      font-size: 12px;
+      line-height: 1.67;
+      color: #5f708a;
+      word-break: normal;
+    }
+  }
+}
+
+.content {
+  position: relative;
+  margin-top: 12px;
+  padding: 12px;
+  border-radius: 4px;
+  background-color: $lightest;
+
+  :global .input {
+    margin-top: 12px;
+    width: 100%;
+  }
+}
+
+.closeIcon {
+  display: inline-block;
+  vertical-align: middle;
+  margin-right: 8px;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  border-radius: 50%;
+  box-shadow: 0 4px 8px 0 rgba(202, 38, 33, 0.2);
+  background-color: #ca2621;
+}
+
+.footer {
+  padding: 10px 20px;
+  border-radius: 0 0 $border-radius $border-radius;
+  background-color: $bg-color;
+  text-align: right;
+
+  button {
+    margin-left: 10px;
+
+    &:first-of-type {
+      margin-left: 0;
+    }
+  }
+}

--- a/src/components/Modal/DisableEIP/index.jsx
+++ b/src/components/Modal/DisableEIP/index.jsx
@@ -1,0 +1,95 @@
+import React from "react"
+import PropTypes from 'prop-types'
+import { toJS } from "mobx"
+import { Button, Icon } from "@kube-design/components"
+import Modal from "../../Base/Modal"
+import styles from './index.module.scss'
+
+export default class DisableEIPModal extends React.Component {
+  static propTypes = {
+    type: PropTypes.string,
+    resource: PropTypes.string,
+    title: PropTypes.string,
+    isSubmitting: PropTypes.bool,
+    visible: PropTypes.bool,
+    onOk: PropTypes.func,
+    onCancel: PropTypes.func,
+    detail: PropTypes.object,
+    store: PropTypes.object,
+  }
+
+  static defaultProps = {
+    isSubmitting: false,
+    onOk() { },
+    onCancel() { },
+    store: {},
+  }
+
+  handleOk = () => {
+    const { onOk, store, detail } = this.props
+    const list = store.list
+    const selectedRowKeys = toJS(list.selectedRowKeys)
+    const newSelectedRowKeys = selectedRowKeys
+      ? selectedRowKeys.filter(item => item !== detail.uid)
+      : ''
+    onOk(
+      {
+        'spec': {
+          'disable': !detail.disable
+        }
+      }
+    )
+    if (selectedRowKeys) list.setSelectRowKeys(newSelectedRowKeys)
+  }
+
+  render() {
+    const { type,
+      resource,
+      title,
+      detail,
+      onCancel,
+      isSubmitting,
+      visible
+    } = this.props
+
+    const action = detail.disable ? 'Enable' : 'Disable'
+    const actionLower = action.toLowerCase()
+
+    const titleText = title || type ? `${action} ${type}` : `${action}`
+    const desc = `Are you sure you want to ${title ? title.split(" ")[0].toLowerCase()
+     : `${actionLower}`} ${type ? `the ${type} ` : ''}${resource}?`
+
+    return (
+      <Modal
+        visible={visible}
+        isSubmitting={isSubmitting}
+        onCancel={onCancel}
+        bodyClassName={styles.modalBody}
+        hideHeader
+        hideFooter>
+        <div className={styles.body}>
+          <Icon name="question" size={20} 
+          color={{ primary: "#FFFFFF", secondary: "#329DCE" }} />
+          <div className={styles.text}>
+            <div className="h6">{titleText}</div>
+            <div className="p">{desc}</div>
+          </div>
+        </div>
+        <div className={styles.footer}>
+          <Button onClick={onCancel} data-test="modal-cancel">
+            Cancel
+          </Button>
+          <Button
+            type="control"
+            loading={isSubmitting}
+            disabled={isSubmitting}
+            onClick={this.handleOk}
+            data-test="modal-ok"
+          >
+            OK
+          </Button>
+        </div>
+      </Modal>
+    )
+  }
+}

--- a/src/components/Modal/DisableEIP/index.module.scss
+++ b/src/components/Modal/DisableEIP/index.module.scss
@@ -1,0 +1,40 @@
+@import '/src/scss/variables';
+
+.modalBody {
+  padding: 0;
+}
+
+.body {
+  padding: 20px;
+  display: flex;
+  flex-direction: row;
+  gap: 2px 12px;
+
+  .text {
+    display: flex;
+    flex-direction: column;
+    gap: 2px 2px;
+
+    :global {
+      .h6 {
+        font-size: $size-small;
+        font-weight: bold;
+        line-height: 1.67;
+        font-family: 'PingFang SC';
+      }
+
+      .p {
+        font-size: $size-small;
+        line-height: 1.67;
+        font-family: 'PingFang SC';
+        color: $second-text-color;
+      }
+    }
+  }
+}
+
+.footer {
+  padding: 12px 20px;
+  background-color: $bg-color;
+  text-align: right;
+}

--- a/src/components/Modal/EditBaseInfo/index.jsx
+++ b/src/components/Modal/EditBaseInfo/index.jsx
@@ -1,0 +1,106 @@
+/*
+  * This file is part of KubeSphere Console.
+  * Copyright (C) 2019 The KubeSphere Console Authors.
+  *
+  * KubeSphere Console is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU Affero General Public License as published by
+  * the Free Software Foundation, either version 3 of the License, or
+  * (at your option) any later version.
+  *
+  * KubeSphere Console is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU Affero General Public License for more details.
+  *
+  * You should have received a copy of the GNU Affero General Public License
+  * along with KubeSphere Console.  If not, see <https://www.gnu.org/licenses/>.
+  */
+
+import React from 'react'
+import PropTypes from 'prop-types'
+import { toJS } from 'mobx'
+import copy from 'fast-copy'
+
+import { Form, Input, TextArea } from '@kube-design/components'
+import Modal from '../../Base/Modal'
+
+export default class EditBasicInfoModal extends React.Component {
+  static propTypes = {
+    detail: PropTypes.object,
+    visible: PropTypes.bool,
+    onOk: PropTypes.func,
+    onCancel: PropTypes.func,
+    isSubmitting: PropTypes.bool,
+  }
+
+  static defaultProps = {
+    visible: false,
+    onOk() { },
+    onCancel() { },
+    isSubmitting: false,
+  }
+
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      formData: copy(toJS(props.detail._originData || props.detail)),
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.visible && this.props.visible !== prevProps.visible) {
+      this.setState({
+        formData: copy(
+          toJS(this.props.detail._originData || this.props.detail)
+        ),
+      })
+    }
+  }
+
+  handleOk = data => {
+    const { onOk, store, detail } = this.props
+    const list = store.list
+    const selectedRowKeys = toJS(list.selectedRowKeys)
+    const newSelectedRowKeys = selectedRowKeys
+      ? selectedRowKeys.filter(item => item !== detail.uid)
+      : ''
+    onOk(data)
+    if (selectedRowKeys) list.setSelectRowKeys(newSelectedRowKeys)
+  }
+
+  render() {
+    const { visible, isSubmitting, onCancel } = this.props
+    const { formData } = this.state
+
+    return (
+      <Modal.Form
+        data={formData}
+        width={691}
+        title="Edit Information"
+        icon="pen"
+        onOk={this.handleOk}
+        okText="OK"
+        onCancel={onCancel}
+        visible={visible}
+        isSubmitting={isSubmitting}
+      >
+        <Form.Item label="Name">
+          <Input name="metadata.name" disabled />
+        </Form.Item>
+        <Form.Item label="Alias" desc="The alias can contain any characters and the maximum length is 63 characters.">
+          <Input
+            name="metadata.annotations['kubesphere.io/alias-name']"
+            maxLength={63}
+          />
+        </Form.Item>
+        <Form.Item label="Description" desc="The description can contain any characters and the maximum length is 256 characters.">
+          <TextArea
+            name="metadata.annotations['kubesphere.io/description']"
+            maxLength={256}
+          />
+        </Form.Item>
+      </Modal.Form>
+    )
+  }
+}

--- a/src/components/Modal/EditSettings/index.jsx
+++ b/src/components/Modal/EditSettings/index.jsx
@@ -1,0 +1,134 @@
+/*
+  * This file is part of KubeSphere Console.
+  * Copyright (C) 2019 The KubeSphere Console Authors.
+  *
+  * KubeSphere Console is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU Affero General Public License as published by
+  * the Free Software Foundation, either version 3 of the License, or
+  * (at your option) any later version.
+  *
+  * KubeSphere Console is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU Affero General Public License for more details.
+  *
+  * You should have received a copy of the GNU Affero General Public License
+  * along with KubeSphere Console.  If not, see <https://www.gnu.org/licenses/>.
+  */
+
+import React from 'react'
+import PropTypes from 'prop-types'
+import { toJS } from 'mobx'
+import copy from 'fast-copy'
+
+import { Columns, Column, Form, Input } from '@kube-design/components'
+import Modal from '../../Base/Modal'
+import NumberInput from "../../NumberInput"
+import styles from "./index.module.scss"
+
+export default class EditSettingsModal extends React.Component {
+  static propTypes = {
+    detail: PropTypes.object,
+    visible: PropTypes.bool,
+    onOk: PropTypes.func,
+    onCancel: PropTypes.func,
+    isSubmitting: PropTypes.bool,
+    title: PropTypes.string,
+    store: PropTypes.object
+  }
+
+  static defaultProps = {
+    title: "",
+    visible: false,
+    onOk() { },
+    onCancel() { },
+    isSubmitting: false,
+    store: {},
+  }
+
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      formData: copy(toJS(props.detail._originData || props.detail)),
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.visible && this.props.visible !== prevProps.visible) {
+      this.setState({
+        formData: copy(
+          toJS(this.props.detail._originData || this.props.detail)
+        ),
+      })
+    }
+  }
+
+  handleOk = data => {
+    const { onOk, store, detail } = this.props
+    const list = store.list
+    const selectedRowKeys = toJS(list.selectedRowKeys)
+    const newSelectedRowKeys = selectedRowKeys
+      ? selectedRowKeys.filter(item => item !== detail.uid)
+      : ''
+    onOk(data)
+    if (selectedRowKeys) list.setSelectRowKeys(newSelectedRowKeys)
+  }
+
+  render() {
+    const { visible, width, isSubmitting, onCancel, title } = this.props
+    const { formData } = this.state
+    const SendMaxDesc = "Maximum number of equivalent routes that OpenELB can send to the peer BGP router for Equal-Cost Multi-Path (ECMP) routing. The default value is 10."
+
+    return (
+      <Modal.Form
+        data={formData}
+        width={width || 960}
+        title={title}
+        onOk={this.handleOk}
+        okText="OK"
+        onCancel={onCancel}
+        visible={visible}
+        isSubmitting={isSubmitting}
+      >
+        <div className={styles.contentWrapper}>
+            <Columns>
+              <Column>
+                <Form.Item
+                  label="Peer AS"
+                  rules={[{ required: true, message: 'Peer AS is required.' }]}
+                >
+                  <NumberInput name="spec.conf.peerAs" min={0} />
+                </Form.Item>
+              </Column>
+              <Column>
+                <Form.Item
+                  label="Neighbor Address"
+                  rules={[{ required: true, message: 'Neighbor Address is required.' }]}
+                >
+                  <Input name="spec.conf.neighborAddress" />
+                </Form.Item>
+              </Column>
+            </Columns>
+            <Columns>
+              <Column>
+                <Form.Item
+                  label="SendMax"
+                  desc={SendMaxDesc}
+                >
+                  <NumberInput name="spec.afiSafis[0].addPaths.config.sendMax" min={0} />
+                </Form.Item>
+              </Column>
+              <Column>
+                <Form.Item
+                  label="BgpPeer Leaf"
+                >
+                  <Input name="spec.nodeSelector.matchLabels['openelb.kubesphere.io/rack']" />
+                </Form.Item>
+              </Column>
+            </Columns>
+          </div>
+      </Modal.Form>
+    )
+  }
+}

--- a/src/components/Modal/EditSettings/index.module.scss
+++ b/src/components/Modal/EditSettings/index.module.scss
@@ -1,0 +1,8 @@
+.contentWrapper {
+  min-height: 500px;
+  max-height: calc(100vh - 222px);
+  overflow-y: auto;
+  width: 920px;
+  margin: 0 auto;
+  padding: 20px 0 48px 0;
+}

--- a/src/components/Modal/EditYAML.jsx/index.jsx
+++ b/src/components/Modal/EditYAML.jsx/index.jsx
@@ -1,0 +1,113 @@
+/*
+  * This file is part of KubeSphere Console.
+  * Copyright (C) 2019 The KubeSphere Console Authors.
+  *
+  * KubeSphere Console is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU Affero General Public License as published by
+  * the Free Software Foundation, either version 3 of the License, or
+  * (at your option) any later version.
+  *
+  * KubeSphere Console is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU Affero General Public License for more details.
+  *
+  * You should have received a copy of the GNU Affero General Public License
+  * along with KubeSphere Console.  If not, see <https://www.gnu.org/licenses/>.
+  */
+
+import React from 'react'
+import PropTypes from 'prop-types'
+import { toJS } from 'mobx'
+import copy from 'fast-copy'
+
+import Modal from '../../Base/Modal'
+import Code from '../Create/Code'
+import styles from './index.module.scss'
+
+export default class EditYAMLModal extends React.Component {
+  static propTypes = {
+    detail: PropTypes.object,
+    visible: PropTypes.bool,
+    onOk: PropTypes.func,
+    onCancel: PropTypes.func,
+    isSubmitting: PropTypes.bool,
+    readOnly: PropTypes.bool,
+  }
+
+  static defaultProps = {
+    visible: false,
+    onOk() { },
+    onCancel() { },
+    isSubmitting: false,
+    readOnly: false,
+  }
+
+  constructor(props) {
+    super(props)
+
+    const detail = copy(toJS(props.detail))
+    this.state = {
+      formData: detail._originData ? { ...detail._originData, ...detail._statusData } : detail,
+    }
+
+    this.codeRef = React.createRef()
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.visible && this.props.visible !== prevProps.visible) {
+      const detail = copy(toJS(this.props.detail))
+      this.setState({
+        formData: detail._originData ?
+          { ...detail._originData, ...detail._statusData } : detail,
+      })
+    }
+  }
+
+  handleOk = data => {
+    const { onOk, store, detail } = this.props
+    const list = store.list
+    const selectedRowKeys = toJS(list.selectedRowKeys)
+    const newSelectedRowKeys = selectedRowKeys
+      ? selectedRowKeys.filter(item => item !== detail.uid)
+      : ''
+    onOk(data)
+    if (selectedRowKeys) list.setSelectRowKeys(newSelectedRowKeys)
+  }
+
+  renderCodeEditor() {
+    const { isSubmitting, onCancel, readOnly } = this.props
+    const { formData } = this.state
+
+    return (
+      <Code
+        ref={this.codeRef}
+        formTemplate={formData}
+        onOk={this.handleOk}
+        onCancel={onCancel}
+        isSubmitting={isSubmitting}
+        okText="OK"
+        readOnly={readOnly}
+      />
+    )
+  }
+
+  render() {
+    const { visible, width, onCancel, readOnly, ...rest } = this.props
+
+    return (
+      <Modal
+        width={width || 960}
+        title="Edit YAML"
+        icon={readOnly ? 'eye' : 'pen'}
+        bodyClassName={styles.body}
+        onCancel={onCancel}
+        visible={visible}
+        {...rest}
+        hideFooter
+      >
+        {this.renderCodeEditor()}
+      </Modal>
+    )
+  }
+}

--- a/src/components/Modal/EditYAML.jsx/index.module.scss
+++ b/src/components/Modal/EditYAML.jsx/index.module.scss
@@ -1,0 +1,5 @@
+.body {
+  overflow: hidden;
+  max-height: none;
+  padding: 0;
+}

--- a/src/components/NumberInput/index.jsx
+++ b/src/components/NumberInput/index.jsx
@@ -1,0 +1,89 @@
+/*
+ * This file is part of KubeSphere Console.
+ * Copyright (C) 2019 The KubeSphere Console Authors.
+ *
+ * KubeSphere Console is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * KubeSphere Console is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with KubeSphere Console.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { isUndefined, isEmpty } from 'lodash'
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import { Input } from '@kube-design/components'
+
+class NumberInput extends React.Component {
+  static propTypes = {
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    min: PropTypes.number,
+    max: PropTypes.number,
+    onChange: PropTypes.func,
+  }
+
+  static defaultProps = {
+    onChange() { },
+  }
+
+  handleChange = e => {
+    const { onChange, min, max } = this.props
+    const { value } = e.target
+
+    if (isEmpty(value)) {
+      onChange(value)
+      return
+    }
+
+    let formatValue = Number(value)
+
+    // invalid number
+    if (isNaN(formatValue)) {
+      return
+    }
+
+    // not smaller than min
+    if (!isUndefined(min) && formatValue < min) {
+      formatValue = min
+    }
+
+    // not bigger than max
+    if (!isUndefined(max) && formatValue > max) {
+      formatValue = max
+    }
+
+    onChange && onChange(formatValue)
+  }
+
+  render() {
+    const {
+      className,
+      value,
+      defaultValue,
+      onChange,
+      ...rest
+    } = this.props
+
+    let formatValue = isUndefined(value) ? defaultValue : value
+
+    const props = {
+      type: 'text',
+      ...rest,
+      value: isUndefined(formatValue) ? '' : formatValue,
+      onChange: this.handleChange,
+    }
+
+    return <Input className={className} {...props} />
+  }
+}
+
+export default NumberInput

--- a/src/pages/BGP/List/index.jsx
+++ b/src/pages/BGP/List/index.jsx
@@ -96,7 +96,7 @@ class List extends Component {
 
     this.trigger('bgpconf.create', {
       store: this.store,
-      success: this.routing.query,
+      success: () => this.store.getConf(),
     })
   }
 
@@ -105,7 +105,7 @@ class List extends Component {
     this.trigger('bgpconf.edit', {
       store: this.store,
       detail: this.bgpConf,
-      success: this.routing.query,
+      success: () => this.store.getConf(),
     })
   }
 

--- a/src/pages/BGP/List/index.jsx
+++ b/src/pages/BGP/List/index.jsx
@@ -12,6 +12,7 @@ import idle from '../../../assets/idle-statusdot.svg'
 import opensent from '../../../assets/opensent-confirm-statusdot.svg'
 import { Icon } from "@kube-design/components"
 import { toJS } from "mobx"
+import { trigger } from "../../../utils/action"
 
 class List extends Component {
   componentDidMount() {
@@ -42,7 +43,11 @@ class List extends Component {
   }
 
   handleCreateClick = () => {
-    console.log('Do you want ro create a BGP? Do it.')
+    const { store } = this.props
+    
+    this.trigger('bgp.create', {
+      store
+    })
   }
 
   getColumns() {
@@ -262,4 +267,4 @@ class List extends Component {
   }
 }
 
-export default withList({ store: new BGPStore(), module: 'bgp' })(List)
+export default withList({ store: new BGPStore(), module: 'bgp' })(trigger(List))

--- a/src/pages/BGP/List/index.jsx
+++ b/src/pages/BGP/List/index.jsx
@@ -13,6 +13,7 @@ import opensent from '../../../assets/opensent-confirm-statusdot.svg'
 import { Icon } from "@kube-design/components"
 import { toJS } from "mobx"
 import { trigger } from "../../../utils/action"
+import { isEmpty } from "lodash"
 
 class List extends Component {
   componentDidMount() {
@@ -44,8 +45,16 @@ class List extends Component {
 
   handleCreateClick = () => {
     const { store } = this.props
-    
+
     this.trigger('bgp.create', {
+      store
+    })
+  }
+
+  handleCreateConfClick = () => {
+    const { store } = this.props
+
+    this.trigger('bgpconf.create', {
       store
     })
   }
@@ -177,73 +186,91 @@ class List extends Component {
     ]
   }
 
+  renderBgpConfEmpty() {
+    return (<div className={styles.empty}>
+      <div className={styles.info}>
+        <Icon name="gateway-duotone" size={40} />
+        <div>
+          <p>BgpConf not Created</p>
+          Create a BgpConf object to configure local BGP properties on OpenELB.
+        </div>
+      </div>
+      <div className={styles.button}>
+        <button onClick={this.handleCreateConfClick}>
+          Create
+        </button>
+      </div>
+    </div>)
+  }
+
   renderBgpConf() {
     const conf = toJS(this.props.store.conf)
 
-    return (<div className={styles.bgpConf}>
-      <div className={styles.frame1}>
-        <div className={styles.summary}>
-          <Icon name="gateway-duotone" size={40} />
+    return (isEmpty(conf) ? this.renderBgpConfEmpty() :
+      (<div className={styles.bgpConf}>
+        <div className={styles.frame1}>
+          <div className={styles.summary}>
+            <Icon name="gateway-duotone" size={40} />
+            <div>
+              <div>
+                <p>{conf.name}</p>
+                BgpConf
+              </div>
+              <div style={{ flexGrow: 2 }}>
+                <p>{moment(new Date(conf.createTime))
+                  .format('YYYY-MM-DD hh:mm:ss') || '-'}</p>
+                Creation Time
+              </div>
+            </div>
+          </div>
+          <button>
+            Edit BgpConf
+          </button>
+        </div>
+
+        <div className={styles.frame2}>
+          <div>
+            <Icon name="duotone" size={40} />
+            <div>
+              <p>{conf.as}</p>
+              ASN
+            </div>
+          </div>
+          <div>
+            <Icon name="network-port" size={40} />
+            <div>
+              <p>{conf.listenPort}</p>
+              ListenPort
+            </div>
+          </div>
+          <div>
+            <Icon name="lab-router" size={40} />
+            <div>
+              <p>{conf.routerID}</p>
+              RouterID
+            </div>
+          </div>
+        </div>
+
+        <div className={styles.frame3}>
           <div>
             <div>
-              <p>{conf.name}</p>
-              BgpConf
+              <span>
+                <div><p>{conf.nodeCount}</p></div>
+              </span>
+              <p>Running Nodes:</p>
             </div>
-            <div style={{ flexGrow: 2 }}>
-              <p>{moment(new Date(conf.createTime))
-                .format('YYYY-MM-DD hh:mm:ss') || '-'}</p>
-              Creation Time
+            <div>
+              {conf.nodes?.map((node, index) => {
+                return (<div key={index}>
+                  <Icon name="nodes" size={40} />
+                  <p>{node}</p>
+                </div>)
+              })}
             </div>
           </div>
         </div>
-        <button>
-          Edit BgpConf
-        </button>
-      </div>
-
-      <div className={styles.frame2}>
-        <div>
-          <Icon name="duotone" size={40} />
-          <div>
-            <p>{conf.as}</p>
-            ASN
-          </div>
-        </div>
-        <div>
-          <Icon name="network-port" size={40} />
-          <div>
-            <p>{conf.listenPort}</p>
-            ListenPort
-          </div>
-        </div>
-        <div>
-          <Icon name="lab-router" size={40} />
-          <div>
-            <p>{conf.routerID}</p>
-            RouterID
-          </div>
-        </div>
-      </div>
-
-      <div className={styles.frame3}>
-        <div>
-          <div>
-            <span>
-              <div><p>{conf.nodeCount}</p></div>
-            </span>
-            <p>Running Nodes:</p>
-          </div>
-          <div>
-            {conf.nodes?.map((node, index) => {
-              return (<div key={index}>
-                <Icon name="nodes" size={40} />
-                <p>{node}</p>
-              </div>)
-            })}
-          </div>
-        </div>
-      </div>
-    </div>)
+      </div>))
   }
 
   render() {

--- a/src/pages/BGP/List/index.module.scss
+++ b/src/pages/BGP/List/index.module.scss
@@ -83,18 +83,13 @@
       }
     }
 
-    &>button {
-      padding: 6px 24px;
+    &>Button {
       background: $light-color02;
       border: 1px solid $light-color06;
-      border-radius: 16px;
-
-      &>p {
-        font-weight: 600;
-        font-size: 12px;
-        line-height: 20px;
-        font-family: 'PingFang SC';
-      }
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      margin: auto 6px;
     }
   }
 
@@ -243,26 +238,15 @@
     }
   }
 
-  .button {
-    filter: drop-shadow(0px 8px 16px rgba(36, 46, 66, 0.28));
+  &>Button {
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    transition: all 0.2S ease-in-out;
     margin: auto 6px;
-
-    &>button {
-      padding: 4px 26px;
-      background: $dark-color07;
-      border-radius: 18px;
-      font-family: 'PingFang SC';
-      font-weight: 600;
-      font-size: 12px;
-      line-height: 20px;
-      color: #FFFFFF;
-    }
+    padding: 6px 28px;
   }
+
   .button:hover {
-    filter:none;
+    filter: none;
   }
 }

--- a/src/pages/BGP/List/index.module.scss
+++ b/src/pages/BGP/List/index.module.scss
@@ -72,6 +72,9 @@
           flex-direction: column;
           flex-grow: 1;
           justify-content: flex-start;
+          font-size: 12px;
+          line-height: 20px;
+          font-family: 'PingFang SC';
 
           &>p {
             font-weight: 600;
@@ -85,7 +88,13 @@
       background: $light-color02;
       border: 1px solid $light-color06;
       border-radius: 16px;
-      font-weight: 600;
+
+      &>p {
+        font-weight: 600;
+        font-size: 12px;
+        line-height: 20px;
+        font-family: 'PingFang SC';
+      }
     }
   }
 
@@ -112,6 +121,9 @@
         flex-direction: column;
         align-items: flex-start;
         padding: 0px;
+        font-size: 12px;
+        line-height: 20px;
+        font-family: 'PingFang SC';
 
         &>p {
           font-weight: 600;
@@ -157,7 +169,10 @@
             align-items: center;
             padding: 2px;
             gap: 4px;
-            
+            font-size: 12px;
+            line-height: 20px;
+            font-family: 'PingFang SC';
+
             &>p {
               font-weight: 600;
               color: $white;
@@ -168,6 +183,9 @@
         &>p {
           font-weight: 600;
           color: $dark-color06;
+          font-size: 12px;
+          line-height: 20px;
+          font-family: 'PingFang SC';
         }
 
         &>div {
@@ -179,12 +197,72 @@
           border-radius: 4px;
           background-color: $light-color02;
           padding: 2px 8px;
-
-          &>p {
-            font-weight: 600;
-          }
+          font-weight: 600;
+          font-size: 12px;
+          line-height: 20px;
+          font-family: 'PingFang SC';
         }
       }
     }
+  }
+}
+
+.empty {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  padding: 12px;
+  gap: 12px;
+  background: #FFFFFF;
+  box-shadow: 0px 4px 8px rgba(36, 46, 66, 0.06);
+  border-radius: 4px;
+  gap: 20px;
+  align-self: stretch;
+  margin-bottom: 12px;
+
+  .info {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 12px;
+    flex-grow: 1;
+
+    &>div {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      font-size: 12px;
+      line-height: 20px;
+      font-family: 'PingFang SC';
+      color: #79879C;
+
+      &>p {
+        font-weight: 600;
+        color: #242E42;
+      }
+    }
+  }
+
+  .button {
+    filter: drop-shadow(0px 8px 16px rgba(36, 46, 66, 0.28));
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    transition: all 0.2S ease-in-out;
+    margin: auto 6px;
+
+    &>button {
+      padding: 4px 26px;
+      background: $dark-color07;
+      border-radius: 18px;
+      font-family: 'PingFang SC';
+      font-weight: 600;
+      font-size: 12px;
+      line-height: 20px;
+      color: #FFFFFF;
+    }
+  }
+  .button:hover {
+    filter:none;
   }
 }

--- a/src/pages/EIP/Detail/index.jsx
+++ b/src/pages/EIP/Detail/index.jsx
@@ -1,11 +1,10 @@
 import { Loading, Tooltip } from "@kube-design/components"
 import { toJS } from "mobx"
-import { inject, observer } from "mobx-react"
+import { observer } from "mobx-react"
 import { Component } from "react"
 import Info from "../../../components/Cards/Info"
 import Service from "../../../components/Lists/Service"
 import EipStore from "../../../stores/eip"
-import { trigger } from "../../../utils/action"
 import checkedApps from "../../../assets/checked-apps.svg"
 import checkedCircleGraph from "../../../assets/checked-circle-graph.svg"
 import checkedEipDuotone from "../../../assets/checked-eip-duotone.svg"
@@ -99,11 +98,11 @@ class Detail extends Component {
     const detail = toJS(this.store.detail)
     return (
       <div className={styles.body}>
-        <Info detail={detail} routing={this.routing} store={this.store} />
+        <Info detail={detail} store={this.store} eip={this.eip} />
         {this.renderStatus(detail)}
       </div>
     )
   }
 }
 
-export default inject("rootStore")(observer(trigger(Detail)))
+export default observer(Detail)

--- a/src/pages/EIP/Detail/index.module.scss
+++ b/src/pages/EIP/Detail/index.module.scss
@@ -33,6 +33,7 @@
         padding: 6px 24px;
 
         &>p {
+          font-family: 'PingFang SC';
           font-weight: 600;
           font-size: 12px;
           line-height: 20px;
@@ -49,6 +50,7 @@
       align-self: stretch;
 
       .valuetext {
+        font-family: 'PingFang SC';
         font-weight: 600;
         font-size: 12px;
         line-height: 20px;
@@ -56,6 +58,7 @@
       }
 
       .keytext {
+        font-family: 'PingFang SC';
         font-weight: 400;
         font-size: 12px;
         line-height: 20px;
@@ -63,6 +66,7 @@
       }
 
       &>p {
+        font-family: 'PingFang SC';
         font-weight: 600;
         font-size: 12px;
         line-height: 20px;

--- a/src/pages/EIP/List/index.jsx
+++ b/src/pages/EIP/List/index.jsx
@@ -17,6 +17,10 @@ class List extends Component {
     return this.props.rootStore.routing
   }
 
+  get store() {
+    return this.props.store
+  }
+
   get BannerProps() {
     return {
       icon: 'eip-duotone',
@@ -27,28 +31,43 @@ class List extends Component {
   }
 
   get itemActions() {
-    const { tableProps, store } = this.props
+    const { tableProps } = this.props
+    const [, deleteAction] = tableProps.itemActions
 
     return [
-      ...tableProps.itemActions,
       {
-        icon: 'pen',
-        key: 'create',
-        text: 'Edit information',
-        onClick: () => {
-          this.trigger('eip.create', {
-            store
-          })
-        }
-      }
+        key: 'yaml',
+        icon: 'eye',
+        text: 'View YAML',
+        action: 'ViewYAML',
+        onClick: item =>
+          this.trigger('eip.yaml.view', {
+            detail: item,
+            success: this.routing.query,
+            store: this.store,
+          }),
+      },
+      {
+        key: 'disable',
+        icon: item => item.disable ? 'start' : 'stop',
+        text: item => item.disable ? 'Enable' : 'Disable',
+        action: 'Disable',
+        onClick: item =>
+        this.trigger('eip.disable', {
+          type: tableProps.name,
+          detail: item,
+          success: this.routing.query,
+          store: this.store
+        })
+      },
+      deleteAction,
     ]
   }
 
   handleCreateClick = () => {
-    const { store } = this.props
-    
     this.trigger('eip.create', {
-      store
+      store: this.store,
+      success: this.routing.query,
     })
   }
 
@@ -169,4 +188,4 @@ class List extends Component {
   }
 }
 
-export default withList({ store: new EIPStore(), module: 'eip' })(trigger(List))
+export default withList({ store: new EIPStore(), module: 'eip', name: 'EIP' })(trigger(List))

--- a/src/steps/bgppeer.js
+++ b/src/steps/bgppeer.js
@@ -1,0 +1,19 @@
+import BaseInfo from "../components/Forms/BGPPeer/BaseInfo"
+import BgpPeerSettings from "../components/Forms/BGPPeer/Settings"
+
+const steps = [
+  {
+    title: 'Basic Information',
+    component: BaseInfo,
+    required: true,
+    icon: 'cdn',
+  },
+  {
+    title: 'BgpPeer Setting',
+    component: BgpPeerSettings,
+    required: true,
+    icon: 'conversion-node',
+  },
+]
+
+export default steps

--- a/src/stores/base.js
+++ b/src/stores/base.js
@@ -187,7 +187,7 @@ class BaseStore {
     return this.submitting(request.put(this.getDetailUrl(params), newObject))
   }
 
-  async patch(params, newObject) {
+  patch(params, newObject) {
     return this.submitting(request.patch(this.getDetailUrl(params), newObject))
   }
 

--- a/src/stores/bgp.js
+++ b/src/stores/bgp.js
@@ -25,11 +25,21 @@ class BGPStore extends Base {
 
     async getConf() {
         this.isLoading = true
+
         const result = await request.get(this.getConfUrl)
-        const conf = {...this.confMapper(result), Kind: 'BgpConf'}
+        const conf = { ...this.confMapper(result), Kind: 'BgpConf' }
+        
         this.conf = conf
         this.isLoading = false
         return conf
+    }
+
+    createConf(data, params = {}) {
+        return this.submitting(request.post(this.getConfUrl, data))
+    }
+
+    async patchConf(newObject) {
+        return this.submitting(request.patch(this.getConfUrl, newObject))
     }
 }
 

--- a/src/stores/bgp.js
+++ b/src/stores/bgp.js
@@ -11,7 +11,9 @@ class BGPStore extends Base {
         super(module)
         makeObservable(this, {
             conf: observable,
-            getConf: action
+            getConf: action,
+            createConf: action,
+            patchConf: action,
         })
     }
 

--- a/src/utils/form.templates.js
+++ b/src/utils/form.templates.js
@@ -7,7 +7,7 @@ const bgpFormTemplate = () => ({
   spec: {
     conf: {
       neighborAddress: '',
-      localAs: '',
+      localAs: 50001,
     },
     afiSafis: [
       {
@@ -33,6 +33,19 @@ const bgpFormTemplate = () => ({
   }
 })
 
+const bgpconfFormTemplate = () => ({
+  apiVersion: 'network.kubesphere.io/v1alpha2',
+  kind: 'BgpConf',
+  metadata: {
+    name: 'default',
+  },
+  spec: {
+    as: 50000,
+    listenPort: 17900,
+    routerId: '',
+  }
+})
+
 const eipFormTemplate = () => ({
   apiVersion: 'network.kubesphere.io/v1alpha2',
   kind: 'Eip',
@@ -52,6 +65,7 @@ const eipFormTemplate = () => ({
 
 const mapperTemplate = {
   bgp: bgpFormTemplate,
+  bgpconf: bgpconfFormTemplate,
   eip: eipFormTemplate
 }
 

--- a/src/utils/form.templates.js
+++ b/src/utils/form.templates.js
@@ -57,7 +57,7 @@ const eipFormTemplate = () => ({
   },
   spec: {
     address: "",
-    protocol: '',
+    protocol: 'bgp',
     interface: '',
     disable: false,
   }

--- a/src/utils/form.templates.js
+++ b/src/utils/form.templates.js
@@ -1,3 +1,38 @@
+const bgpFormTemplate = () => ({
+  apiVersion: 'network.kubesphere.io/v1alpha2',
+  kind: 'BgpPeer',
+  metadata: {
+    name: '',
+  },
+  spec: {
+    conf: {
+      neighborAddress: '',
+      localAs: '',
+    },
+    afiSafis: [
+      {
+        conf: {
+          family: {
+            afi: "AFI_IP",
+            safi: "SAFI_UNICAST"
+          },
+          enabled: true,
+        },
+        addPaths: {
+          config: {
+            sendMax: 10,
+          }
+        },
+      }
+    ],
+    nodeSelector: {
+      matchLabels: {
+        "openelb.kubesphere.io/rack": "",
+      }
+    },
+  }
+})
+
 const eipFormTemplate = () => ({
   apiVersion: 'network.kubesphere.io/v1alpha2',
   kind: 'Eip',
@@ -16,6 +51,7 @@ const eipFormTemplate = () => ({
 })
 
 const mapperTemplate = {
+  bgp: bgpFormTemplate,
   eip: eipFormTemplate
 }
 

--- a/src/utils/form.templates.js
+++ b/src/utils/form.templates.js
@@ -6,8 +6,8 @@ const bgpFormTemplate = () => ({
   },
   spec: {
     conf: {
+      peerAs: 50001,
       neighborAddress: '',
-      localAs: 50001,
     },
     afiSafis: [
       {

--- a/src/utils/form.templates.js
+++ b/src/utils/form.templates.js
@@ -11,7 +11,7 @@ const bgpFormTemplate = () => ({
     },
     afiSafis: [
       {
-        conf: {
+        config: {
           family: {
             afi: "AFI_IP",
             safi: "SAFI_UNICAST"

--- a/src/utils/object.mapper.js
+++ b/src/utils/object.mapper.js
@@ -54,7 +54,7 @@ const BGPMapper = item => {
     bgpPeerLeaf: get(item,
       'spec.nodeSelector.matchLabels["openelb.kubesphere.io/rack"]', "-"),
     description: get(item,
-      `status.nodesPeerStatus.${nodeField}.peerState.description`, ""),
+      'metadata.annotations["openelb.io/description"]', ""),
     _originData: getOriginData(item),
   })
 }

--- a/src/utils/object.mapper.js
+++ b/src/utils/object.mapper.js
@@ -67,7 +67,7 @@ const BGPConfMapper = item => ({
   listenPort: get(item, 'spec.listenPort', "-"),
   routerID: get(item, 'spec.routerId', ""),
   nodeCount: item.status ? size(item.status.nodesConfStatus, 0) : 0,
-  nodes: item.status ? Object.keys(item.status.nodesConfStatus) : [],
+  nodes: item.status && item.status.nodesConfStatus ? Object.keys(item.status.nodesConfStatus) : [],
   _originData: getOriginData(item),
   _statusData: pick(item, ['status'])
 })

--- a/src/utils/object.mapper.js
+++ b/src/utils/object.mapper.js
@@ -2,6 +2,7 @@ import {
   get,
   isObject,
   omit,
+  pick,
   size,
 } from 'lodash'
 
@@ -56,6 +57,7 @@ const BGPMapper = item => {
     description: get(item,
       'metadata.annotations["openelb.io/description"]', ""),
     _originData: getOriginData(item),
+    _statusData: pick(item, ['status'])
   })
 }
 
@@ -64,9 +66,10 @@ const BGPConfMapper = item => ({
   as: get(item, 'spec.as', ""),
   listenPort: get(item, 'spec.listenPort', "-"),
   routerID: get(item, 'spec.routerId', ""),
-  nodeCount: size(item.status.nodesConfStatus, 0),
-  nodes: Object.keys(item.status.nodesConfStatus),
+  nodeCount: item.status ? size(item.status.nodesConfStatus, 0) : 0,
+  nodes: item.status ? Object.keys(item.status.nodesConfStatus) : [],
   _originData: getOriginData(item),
+  _statusData: pick(item, ['status'])
 })
 
 const EIPMapper = item => ({
@@ -86,6 +89,7 @@ const EIPMapper = item => ({
   ready: get(item, 'status.ready', false),
   used: get(item, 'status.used', []),
   _originData: getOriginData(item),
+  _statusData: pick(item, ['status'])
 })
 
 const Mappers = {


### PR DESCRIPTION
This PR includes the following updates/changes

1. Trigger method is used to perform actions on the EIP Details page.
2. Create and edit of BGPConf now show the changes immediately after confirm button is clicked.
3. The EditYAML and EditSettings form now uses PUT request instead of PATCH, so use of null is no longer required to remove an already existing field of a resource object.

With these updates the console is now good enough for use by the users of OpenELB. Sadly, searching and sorting in tables are the only features that are not working due to unknown reasons. Also, errors are not shown/notified upon creation/modification attempt of OpenELB resources using form or yaml.

https://github.com/AnuragThePathak/openelb/tree/put-yaml is the fork of OpenELB that was to test the console.

https://user-images.githubusercontent.com/75429250/195650712-2dc98a2c-afbd-4768-8c82-9ab5f13bf57c.mov



https://user-images.githubusercontent.com/75429250/195649875-03e8f091-cd76-48bd-91f0-0d4290eadeee.mov




https://github.com/openelb/openelb/issues/244